### PR TITLE
Fix: Adjust n_ubatch for non-causal attention to prevent crashes

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -883,8 +883,10 @@ int llama_context::decode(llama_batch & inp_batch) {
 
     GGML_ASSERT(n_tokens_all <= cparams.n_batch);
 
-    GGML_ASSERT((cparams.causal_attn || cparams.n_ubatch >= n_tokens_all) && "non-causal attention requires n_ubatch >= n_tokens");
-
+    GGMLif (!(cparams.causal_attn || cparams.n_ubatch >= n_tokens_all)) {
+    printf("Warning: Non-causal attention requires n_ubatch >= n_tokens. Adjusting n_ubatch to meet requirements.\n");
+    cparams.n_ubatch = n_tokens_all; // Adjust the micro-batch size
+}
     if (t_compute_start_us == 0) {
         t_compute_start_us = ggml_time_us();
     }


### PR DESCRIPTION
If non-causal attention is enabled and n_ubatch < n_tokens, the code can crash. This change adds a fallback to automatically set n_ubatch = n_tokens_all in such cases, with a warning printed to the user.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
